### PR TITLE
Experimental: Form validation with multiple atoms

### DIFF
--- a/src/atomWithValidate.ts
+++ b/src/atomWithValidate.ts
@@ -13,7 +13,7 @@ type AsyncState<Value> = CommonState<Value> &
     | { isValidating: false; isValid: false; error: unknown }
   );
 
-type SyncState<Value> = CommonState<Value> &
+export type SyncState<Value> = CommonState<Value> &
   ({ isValid: true } | { isValid: false; error: unknown });
 
 type CommonOptions<Value> = {

--- a/src/atomsToForm.ts
+++ b/src/atomsToForm.ts
@@ -1,0 +1,54 @@
+import { atom } from 'jotai';
+import { SyncState } from './atomWithValidate';
+
+// Temporary type def
+type CollectionOfAtomValidate = {
+  [k: string]: any;
+};
+
+type FormArg = {
+  key: string;
+  value: unknown;
+};
+
+// TODO: add aync handling
+// TODO: add proper generics for infering the collection
+export const atomsToForm = (atoms: CollectionOfAtomValidate) => {
+  return atom(
+    (get) => {
+      let isValid = true;
+      let errors: null | Array<unknown> = null;
+      let isDirty = false;
+
+      const values = Object.fromEntries(
+        Object.entries(atoms).map(([k, v]) => {
+          const val: SyncState<any> = get(v);
+
+          if (val.isDirty) {
+            isDirty = true;
+          }
+
+          if (!val.isValid && val.error) {
+            isValid = false;
+            if (!errors) {
+              errors = [];
+            }
+            errors.push(val.error);
+          }
+
+          return [k, val];
+        }),
+      );
+
+      return {
+        values,
+        errors,
+        isValid,
+        isDirty,
+      };
+    },
+    (_, set, arg: FormArg) => {
+      if (atoms[arg.key]) set(atoms[arg.key], arg.value);
+    },
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { atomWithValidate } from './atomWithValidate';
+export { atomsToForm } from './atomsToForm';


### PR DESCRIPTION
Extending #3 

---

The current implementation leaves the `atomWithValidate` as is and atomic, thus making it reusable in other components when needed but still providing a way to combine multiple such atoms into a form and allowing both set and get on these with the original validation properties. 

In addition to that,
a form atom level  `isValid`,`isDirty`, `errors` is also added for handling overall states like button submissions
