### PR TITLE
Feat: ability to validate atoms , `validateAtoms`

### DIFF
--- a/__tests__/02_form_validation.tsx
+++ b/__tests__/02_form_validation.tsx
@@ -3,7 +3,7 @@ import 'regenerator-runtime/runtime';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { useAtom } from 'jotai';
-import { atomWithValidate, validateAtom } from '../src/index';
+import { atomWithValidate, validateAtoms } from '../src/index';
 
 describe('validateForm', () => {
   it('basic form level validation', async () => {
@@ -24,21 +24,22 @@ describe('validateForm', () => {
       },
     });
 
-    const formStateAtom = validateAtom(async (getValues) => {
-      const values = getValues({
+    const formStateAtom = validateAtoms(
+      {
         firstName: firstNameAtom,
         lastName: lastNameAtom,
-      });
+      },
+      async (values) => {
+        if (
+          String(values.firstName).length + String(values.lastName).length >
+          12
+        ) {
+          throw new Error('The full name cannot be greater than 12 characters');
+        }
 
-      if (
-        String(values.firstName).length + String(values.lastName).length >
-        12
-      ) {
-        throw new Error('The full name cannot be greater than 12 characters');
-      }
-
-      return true;
-    });
+        return true;
+      },
+    );
 
     const Component = () => {
       const [firstName, setFirstNameValue] = useAtom(firstNameAtom);

--- a/__tests__/02_form_validation.tsx
+++ b/__tests__/02_form_validation.tsx
@@ -37,7 +37,7 @@ describe('validateForm', () => {
           throw new Error('The full name cannot be greater than 12 characters');
         }
 
-        return true;
+        return values;
       },
     );
 

--- a/__tests__/02_form_validation.tsx
+++ b/__tests__/02_form_validation.tsx
@@ -55,6 +55,7 @@ describe('validateForm', () => {
 
           <div>{`formValid: ${JSON.stringify(formState.isValid)}`}</div>
           <div>{`formError: ${String(formState.error)}`}</div>
+          <div>{`formValues: ${JSON.stringify(formState.values)}`}</div>
 
           <button
             type="button"
@@ -93,6 +94,7 @@ describe('validateForm', () => {
 
       getByText('formValid: true');
       getByText('formError: null');
+      getByText('formValues: {"firstName":"dai","lastName":"shi"}');
     });
 
     // force invalid data and check it
@@ -103,6 +105,7 @@ describe('validateForm', () => {
       getByText('lastName: longend');
       getByText('lastNameValid: true');
       getByText('formValid: false');
+      getByText('formValues: {"firstName":"longstart","lastName":"longend"}');
       getByText(
         'formError: Error: The full name cannot be greater than 12 characters',
       );
@@ -117,6 +120,7 @@ describe('validateForm', () => {
       getByText('lastNameValid: true');
       getByText('formValid: true');
       getByText('formError: null');
+      getByText('formValues: {"firstName":"dai","lastName":"shi"}');
     });
   });
 });

--- a/__tests__/02_form_validation.tsx
+++ b/__tests__/02_form_validation.tsx
@@ -1,0 +1,121 @@
+import 'regenerator-runtime/runtime';
+
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useAtom } from 'jotai';
+import { atomWithValidate, validateAtom } from '../src/index';
+
+describe('validateForm', () => {
+  it('basic form level validation', async () => {
+    const firstNameAtom = atomWithValidate('dai', {
+      validate: (v: unknown) => {
+        if (String(v).length < 2) {
+          throw new Error('First Name should be greater than 3 characters');
+        }
+        return v;
+      },
+    });
+    const lastNameAtom = atomWithValidate('shi', {
+      validate: (v: unknown) => {
+        if (String(v).length < 2) {
+          throw new Error('Last Name should be greater than 3 characters');
+        }
+        return v;
+      },
+    });
+
+    const formStateAtom = validateAtom(async (getValues) => {
+      const values = getValues({
+        firstName: firstNameAtom,
+        lastName: lastNameAtom,
+      });
+
+      if (
+        String(values.firstName).length + String(values.lastName).length >
+        12
+      ) {
+        throw new Error('The full name cannot be greater than 12 characters');
+      }
+
+      return true;
+    });
+
+    const Component = () => {
+      const [firstName, setFirstNameValue] = useAtom(firstNameAtom);
+      const [lastName, setLastNameValue] = useAtom(lastNameAtom);
+      const [formState] = useAtom(formStateAtom);
+
+      return (
+        <>
+          <div>{`firstName: ${firstName.value}`}</div>
+          <div>{`firstNameValid: ${JSON.stringify(firstName.isValid)}`}</div>
+          <div>{`lastName: ${lastName.value}`}</div>
+          <div>{`lastNameValid: ${JSON.stringify(lastName.isValid)}`}</div>
+
+          <div>{`formValid: ${JSON.stringify(formState.isValid)}`}</div>
+          <div>{`formError: ${String(formState.error)}`}</div>
+
+          <button
+            type="button"
+            onClick={() => {
+              setFirstNameValue('dai');
+              setLastNameValue('shi');
+            }}
+          >
+            valid form
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setFirstNameValue('longstart');
+              setLastNameValue('longend');
+            }}
+          >
+            invalid form
+          </button>
+        </>
+      );
+    };
+
+    const { getByText } = render(
+      <div>
+        <Component />
+      </div>,
+    );
+
+    // initial form state
+    await waitFor(() => {
+      getByText('firstName: dai');
+      getByText('firstNameValid: true');
+      getByText('lastName: shi');
+      getByText('lastNameValid: true');
+
+      getByText('formValid: true');
+      getByText('formError: null');
+    });
+
+    // force invalid data and check it
+    fireEvent.click(getByText('invalid form'));
+    await waitFor(() => {
+      getByText('firstName: longstart');
+      getByText('firstNameValid: true');
+      getByText('lastName: longend');
+      getByText('lastNameValid: true');
+      getByText('formValid: false');
+      getByText(
+        'formError: Error: The full name cannot be greater than 12 characters',
+      );
+    });
+
+    // force valid data and check it
+    fireEvent.click(getByText('valid form'));
+    await waitFor(() => {
+      getByText('firstName: dai');
+      getByText('firstNameValid: true');
+      getByText('lastName: shi');
+      getByText('lastNameValid: true');
+      getByText('formValid: true');
+      getByText('formError: null');
+    });
+  });
+});

--- a/__tests__/02_form_validation.tsx
+++ b/__tests__/02_form_validation.tsx
@@ -35,10 +35,7 @@ describe('validateForm', () => {
         lastName: lastNameAtom,
       },
       (values) => {
-        if (
-          ((values.firstName as string) + (values.lastName as string)).length >
-          12
-        ) {
+        if ((values.firstName + values.lastName).length > 12) {
           throw new Error('The full name cannot be greater than 12 characters');
         }
       },
@@ -136,16 +133,9 @@ describe('validateForm', () => {
       validate: (v) => v,
     });
 
-    // FIXME: there's an issue with the types
-    // not being able to inherit dynamic atom types
-    // remove the below once those are fixed.
     const formStateAtom = validateAtoms(
       {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         name: nameAtom,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         age: ageAtom,
       },
       async (values) => {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "prettier": "^2.6.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "regenerator-runtime": "^0.13.9",
     "ts-jest": "^27.1.4",
     "ts-loader": "^9.2.8",
     "typescript": "^4.6.3",

--- a/src/atomWithValidate.ts
+++ b/src/atomWithValidate.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai';
 import type { WritableAtom, SetStateAction } from 'jotai';
 
-type CommonState<Value> = {
+export type CommonState<Value> = {
   value: Value;
   isDirty: boolean;
 };

--- a/src/atomWithValidate.ts
+++ b/src/atomWithValidate.ts
@@ -6,14 +6,14 @@ type CommonState<Value> = {
   isDirty: boolean;
 };
 
-type AsyncState<Value> = CommonState<Value> &
+export type AsyncState<Value> = CommonState<Value> &
   (
     | { isValidating: true }
     | { isValidating: false; isValid: true }
     | { isValidating: false; isValid: false; error: unknown }
   );
 
-type SyncState<Value> = CommonState<Value> &
+export type SyncState<Value> = CommonState<Value> &
   ({ isValid: true } | { isValid: false; error: unknown });
 
 type CommonOptions<Value> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { atomWithValidate } from './atomWithValidate';
-export { validateAtom } from './validateForm';
+export { validateAtoms } from './validateAtoms';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { atomWithValidate } from './atomWithValidate';
+export { validateAtom } from './validateForm';

--- a/src/validateAtoms.ts
+++ b/src/validateAtoms.ts
@@ -3,10 +3,9 @@ import { loadable } from 'jotai/utils';
 
 import type { CommonState } from './atomWithValidate';
 
-export type GetValues = <Value>(labeledAtoms: LabeledAtoms<Value>) => {
-  [k: string]: Value;
-};
-export type Validator = <Value>(values: { [k: string]: Value }) => Promise<any>;
+export type Validator = <Values extends Record<string, unknown>>(
+  values: Values,
+) => Promise<Values>;
 
 export type ValidatorState = {
   isValid: undefined | boolean;
@@ -14,7 +13,6 @@ export type ValidatorState = {
   isValidating: undefined | boolean;
 };
 
-// Wrapper type on top of the 2 outputs from `atomWithValidate`
 type AtomWithValidation<Value> = WritableAtom<
   CommonState<Value>,
   SetStateAction<Value>

--- a/src/validateAtoms.ts
+++ b/src/validateAtoms.ts
@@ -5,7 +5,7 @@ import type { CommonState } from './atomWithValidate';
 
 export type Validator = <Values extends Record<string, unknown>>(
   values: Values,
-) => Promise<unknown>;
+) => void | Promise<void>;
 
 export type ValidatorState = {
   isValid: undefined | boolean;
@@ -22,9 +22,7 @@ type State<Values extends Record<string, unknown>> = {
   values: Values;
 } & ValidatorState;
 
-type LabeledAtoms<Value> = {
-  [k: string]: AtomWithValidation<Value>;
-};
+type LabeledAtoms<Value> = Record<string, AtomWithValidation<Value>>;
 
 export const validateAtoms = <Value>(
   labeledAtoms: LabeledAtoms<Value>,

--- a/src/validateAtoms.ts
+++ b/src/validateAtoms.ts
@@ -32,7 +32,7 @@ export const validateAtoms = <
   labeledAtoms: AtomGroup,
   validator: Validator<Keys, inferGeneric<Vals>>,
 ) => {
-  const $getSourceAtomVals = (get: Getter) => {
+  const valsAtom = atom((get: Getter) => {
     const values = Object.fromEntries(
       Object.entries(labeledAtoms).map(([k, v]) => {
         const atomValue = get(v);
@@ -40,16 +40,15 @@ export const validateAtoms = <
       }),
     );
     return values as Record<Keys, inferGeneric<Vals>>;
-  };
+  });
 
   const baseAtom = atom(async (get) => {
     // extract value from each atom and assign to the given key as label
-    const values = $getSourceAtomVals(get);
-    return validator(values);
+    return validator(get(valsAtom));
   });
 
   const normalizerAtom = atom((get) => {
-    const values = $getSourceAtomVals(get);
+    const values = get(valsAtom);
     const state = get(loadable(baseAtom));
     return {
       ...state,

--- a/src/validateForm.ts
+++ b/src/validateForm.ts
@@ -1,7 +1,7 @@
 import { atom, SetStateAction, WritableAtom } from 'jotai';
 import { loadable } from 'jotai/utils';
 
-import type { CommonState, AsyncState, SyncState } from './atomWithValidate';
+import type { CommonState } from './atomWithValidate';
 
 export type GetValues = <Value>(labeledAtoms: LabeledAtoms<Value>) => {
   [k: string]: Value;
@@ -15,9 +15,10 @@ export type ValidatorState = {
 };
 
 // Wrapper type on top of the 2 outputs from `atomWithValidate`
-type AtomWithValidation<Value> =
-  | WritableAtom<AsyncState<Value>, SetStateAction<Value>>
-  | WritableAtom<SyncState<Value>, SetStateAction<Value>>;
+type AtomWithValidation<Value> = WritableAtom<
+  CommonState<Value>,
+  SetStateAction<Value>
+>;
 
 type LabeledAtoms<Value> = {
   [k: string]: AtomWithValidation<Value>;
@@ -30,9 +31,7 @@ export const validateAtom = (validator: Validator) => {
     const getValues = <Value>(labeledAtoms: LabeledAtoms<Value>) => {
       const values = Object.fromEntries(
         Object.entries(labeledAtoms).map(([k, v]) => {
-          const atomValue = get(
-            v as WritableAtom<CommonState<Value>, SetStateAction<Value>>,
-          );
+          const atomValue = get(v);
 
           return [k, atomValue.value];
         }),

--- a/src/validateForm.ts
+++ b/src/validateForm.ts
@@ -1,7 +1,7 @@
 import { atom, SetStateAction, WritableAtom } from 'jotai';
 import { loadable } from 'jotai/utils';
 
-import type { AsyncState, SyncState } from './atomWithValidate';
+import type { CommonState, AsyncState, SyncState } from './atomWithValidate';
 
 export type GetValues = <Value>(labeledAtoms: LabeledAtoms<Value>) => {
   [k: string]: Value;
@@ -10,7 +10,7 @@ export type Validator = (getValues: GetValues) => Promise<any>;
 
 export type ValidatorState = {
   isValid: undefined | boolean;
-  error: undefined | Error | unknown;
+  error: null | Error | unknown;
   isValidating: undefined | boolean;
 };
 
@@ -30,9 +30,9 @@ export const validateAtom = (validator: Validator) => {
     const getValues = <Value>(labeledAtoms: LabeledAtoms<Value>) => {
       const values = Object.fromEntries(
         Object.entries(labeledAtoms).map(([k, v]) => {
-          // @ts-expect-error intersecting types of `AtomWithValidate<Value>` doesn't
-          // satisfy the `get` type requirements
-          const atomValue = get(v);
+          const atomValue = get(
+            v as WritableAtom<CommonState<Value>, SetStateAction<Value>>,
+          );
 
           return [k, atomValue.value];
         }),

--- a/src/validateForm.ts
+++ b/src/validateForm.ts
@@ -23,7 +23,7 @@ type LabeledAtoms<Value> = {
   [k: string]: AtomWithValidation<Value>;
 };
 
-export const validateAtomLoadable = (validator: Validator) => {
+export const validateAtom = (validator: Validator) => {
   const baseAtom = atom(async (get) => {
     // helper to convert an object of {string:atom} => {string: value}
     // currently expected `atom` to be one of the output types of `atomWithValidate`

--- a/src/validateForm.ts
+++ b/src/validateForm.ts
@@ -1,0 +1,74 @@
+import { atom, SetStateAction, WritableAtom } from 'jotai';
+import { loadable } from 'jotai/utils';
+
+import type { AsyncState, SyncState } from './atomWithValidate';
+
+export type GetValues = <Value>(labeledAtoms: LabeledAtoms<Value>) => {
+  [k: string]: Value;
+};
+export type Validator = (getValues: GetValues) => Promise<any>;
+
+export type ValidatorState = {
+  isValid: undefined | boolean;
+  error: undefined | Error | unknown;
+  isValidating: undefined | boolean;
+};
+
+// Wrapper type on top of the 2 outputs from `atomWithValidate`
+type AtomWithValidation<Value> =
+  | WritableAtom<AsyncState<Value>, SetStateAction<Value>>
+  | WritableAtom<SyncState<Value>, SetStateAction<Value>>;
+
+type LabeledAtoms<Value> = {
+  [k: string]: AtomWithValidation<Value>;
+};
+
+export const validateAtomLoadable = (validator: Validator) => {
+  const baseAtom = atom(async (get) => {
+    // helper to convert an object of {string:atom} => {string: value}
+    // currently expected `atom` to be one of the output types of `atomWithValidate`
+    const getValues = <Value>(labeledAtoms: LabeledAtoms<Value>) => {
+      const values = Object.fromEntries(
+        Object.entries(labeledAtoms).map(([k, v]) => {
+          // @ts-expect-error intersecting types of `AtomWithValidate<Value>` doesn't
+          // satisfy the `get` type requirements
+          const atomValue = get(v);
+
+          return [k, atomValue.value];
+        }),
+      );
+      return values;
+    };
+
+    return validator(getValues);
+  });
+
+  const derv = atom((get) => {
+    const validatorState = get(loadable(baseAtom));
+
+    const next: ValidatorState = {
+      isValid: true,
+      isValidating: undefined,
+      error: null,
+    };
+
+    if (validatorState.state === 'loading') {
+      next.isValid = undefined;
+      next.isValidating = true;
+    }
+
+    if (validatorState.state === 'hasError') {
+      next.isValid = false;
+      next.error = validatorState.error;
+    }
+
+    if (validatorState.state === 'hasData') {
+      next.isValid = true;
+      next.error = null;
+    }
+
+    return next;
+  });
+
+  return derv;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6254,7 +6254,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
Adds the `validateAtoms` implementation for overall form atom validation.

Usage example:

```js
import { atomWithValidate, validateAtoms } from "jotai-form";

const nameAtom = atomWithValidate("foo", {
  validate: (v) => v, // individual atom validation (nothing here just for this example)
});

const ageAtom = atomWithValidate(18, {
  validate: (v) => v, // individual atom validation (nothing here just for this example)
});

const formStateAtom = validateAtoms(
  {
    name: nameAtom,
    age: ageAtom,
  },
  async (values) => {
   // validating the entire atom group for a specific form
    await Yup.object()
      .shape({
        name: Yup.string().min(3).required(),
        age: Yup.number().min(18).required(),
      })
      .validate(values);
  }
);

export const Component = () => {
  const [name, setName] = useAtom(nameAtom);
  const [age, setAge] = useAtom(ageAtom);
  const [formState] = useAtom(formStateAtom);

  return (
    <>
      <input
        placeholder="Name"
        value={name.value}
        onChange={(e) => setName(e.target.value)}
      />
      <input
        type="number"
        placeholder="Age"
        value={age.value}
        onChange={(e) => setAge(parseInt(e.target.value,10))}
      />
      <button type="submit" disabled={!formState.isValid}>Submit</button>
    </>
  );
};

```
