### PR TITLE
approaches for `touched` state

### DIFF
--- a/examples/05_experiments/package.json
+++ b/examples/05_experiments/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "jotai-form-example",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "jotai": "latest",
+    "jotai-form": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-scripts": "latest"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/05_experiments/public/index.html
+++ b/examples/05_experiments/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>jotai-form example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/05_experiments/src/index.js
+++ b/examples/05_experiments/src/index.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { useAtom } from 'jotai';
+import { atomWithValidate, atomWithValidateExtended } from 'jotai-form';
+
+const fieldAtom = atomWithValidate(0, {
+  validate: (v) => {
+    const n = Number(v);
+    if (Number.isNaN(n)) {
+      throw new Error('not a number');
+    }
+    return n;
+  },
+});
+
+const fieldExtended = atomWithValidateExtended(fieldAtom);
+
+const Field = () => {
+  const [state, setValue] = useAtom(fieldAtom);
+  const [formState, setFormState] = useAtom(fieldExtended);
+
+  return (
+    <div>
+      <span>{formState.isDirty && '*'}</span>
+      <input
+        value={formState.value}
+        onChange={(e) => setFormState(e.target.value)}
+        onBlur={() => setFormState('TOUCHED')}
+      />
+      <span>{formState.isValid ? 'Valid' : `${state.error}`}</span>{' '}
+      <span>{formState.touched ? 'Touched' : 'Untouched'}</span>
+    </div>
+  );
+};
+
+const App = () => {
+  return (
+    <div>
+      <Field />
+    </div>
+  );
+};
+
+createRoot(document.getElementById('app')).render(<App />);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "examples:01_minimal": "DIR=01_minimal EXT=js webpack serve",
     "examples:02_typescript": "DIR=02_typescript EXT=tsx webpack serve",
     "examples:03_joi": "DIR=03_joi EXT=tsx webpack serve",
-    "examples:04_demo": "DIR=04_demo EXT=js webpack serve"
+    "examples:04_demo": "DIR=04_demo EXT=js webpack serve",
+    "examples:05_experiments": "DIR=05_experiments EXT=js webpack serve"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/src/atomWithValidateExtended.ts
+++ b/src/atomWithValidateExtended.ts
@@ -1,0 +1,32 @@
+import { atom } from 'jotai';
+import { atomWithDefault } from 'jotai/utils';
+
+const ACTIONS: string[] = ['TOUCHED', 'UNTOUCHED'];
+
+export const atomWithValidateExtended = (baseAtom: any) => {
+  const extended = atomWithDefault((get) => ({
+    touched: false,
+    ...get(baseAtom),
+  }));
+
+  const derv = atom(
+    (get) => get(extended),
+    (get, set, update) => {
+      if (typeof update === 'string' && ACTIONS.indexOf(update) > -1) {
+        const prev = get(extended);
+        set(extended, {
+          ...prev,
+          touched: update === 'TOUCHED',
+        });
+        return;
+      }
+      const prev = get(extended);
+      set(extended, {
+        ...prev,
+        value: update,
+      });
+    },
+  );
+
+  return derv;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { atomWithValidate } from './atomWithValidate';
+export { atomWithValidateExtended } from './atomWithValidateExtended';
 export { validateAtoms } from './validateAtoms';


### PR DESCRIPTION
The requirement is to be able to add the `touched` state and to be able to modify the same as required. 

Since it's just one field, we most probably would want to add this to `atomWithValidate` and change the `setter` to 
accept special ACTION tokens.

A variation of this has been implemented and added as an example to the repo. 

> **Note** : the variation is a new `atom` just for this experiment and to test the API of using value + action. We'd actually be adding the same functionality in the original `atomWithValidate` if the API seems reasonable
