### PR TITLE
Maintenance update to jotai v2.2.2 for dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^27.5.1",
     "joi": "^17.7.0",
-    "jotai": "^2.0.3",
+    "jotai": "^2.2.2",
     "microbundle": "^0.14.2",
     "normalize.css": "^8.0.1",
     "npm-run-all": "^4.1.5",
@@ -97,6 +97,6 @@
     "zod": "^3.19.1"
   },
   "peerDependencies": {
-    "jotai": ">=1.11.0"
+    "jotai": ">=2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5133,10 +5133,10 @@ joi@^17.7.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
-jotai@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.0.3.tgz#3b67cda9f6d5feb70a14db0b842a9873aacda8b5"
-  integrity sha512-MMjhSPAL3RoeZD9WbObufRT2quThEAEknHHridf2ma8Ml7ZVQmUiHk0ssdbR3F0h3kcwhYqSGJ59OjhPge7RRg==
+jotai@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.2.2.tgz#1e181789dcc01ced8240b18b95d9fa10169f9366"
+  integrity sha512-Cn8hnBg1sc5ppFwEgVGTfMR5WSM0hbAasd/bdAwIwTaum0j3OUPqBSC4tyk3jtB95vicML+RRWgKFOn6gtfN0A==
 
 js-sdsl@^4.1.4:
   version "4.2.0"


### PR DESCRIPTION
Also , makes the min resolution to v2, since v2 API's and internals are now used